### PR TITLE
Add arguments and handling of custom configs and services

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ vim /opt/letsencrypt-routeros/letsencrypt-routeros.settings
 | ROUTEROS_SSH_PORT | 22 | RouterOS\Mikrotik PORT |
 | ROUTEROS_PRIVATE_KEY | /opt/letsencrypt-routeros/id_rsa | Private RSA Key to connecto to RouterOS |
 | DOMAIN | mydomain.com | Use main domain for wildcard certificate or subdomain for subdomain certificate |
+| SETUP_SERVICES | (SSTP WWW API) | Array of services for which certificate will be installed |
+| SSH_STRICT_KEY_CHECKING | yes | Allows to override SSH option StrictHostKeyChecking |
+| SSH_ACCEPTED_ALGORITHMS | ssh-rsa,ssh-dsa | Allows to override SSH option PubkeyAcceptedAlgorithms |
 
 
 Change permissions:
@@ -98,12 +101,12 @@ certbot certonly --preferred-challenges=dns --manual -d $DOMAIN --manual-public-
 ### Usage of the script
 *To use settings from the settings file:*
 ```sh
-./opt/letsencrypt-routeros/letsencrypt-routeros.sh
+/opt/letsencrypt-routeros/letsencrypt-routeros.sh -c letsencrypt-routeros.settings
 ```
 *To use script without settings file:*
 
 ```sh
-./opt/letsencrypt-routeros/letsencrypt-routeros.sh [RouterOS User] [RouterOS Host] [SSH Port] [SSH Private Key] [Domain]
+/opt/letsencrypt-routeros/letsencrypt-routeros.sh -u [RouterOS User] -h [RouterOS Host] -p [SSH Port] -k [SSH Private Key] -d [Domain]
 ```
 *To use script with CertBot hooks for wildcard domain:*
 ```sh

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ vim /opt/letsencrypt-routeros/letsencrypt-routeros.settings
 | ROUTEROS_USER | admin | user with admin rights to connect to RouterOS |
 | ROUTEROS_HOST | 10.0.254.254 | RouterOS\Mikrotik IP |
 | ROUTEROS_SSH_PORT | 22 | RouterOS\Mikrotik PORT |
-| ROUTEROS_PRIVATE_KEY | /opt/letsencrypt-routeros/id_rsa | Private RSA Key to connecto to RouterOS |
+| ROUTEROS_PRIVATE_KEY | /opt/letsencrypt-routeros/id_rsa | Private RSA Key to connect to RouterOS |
 | DOMAIN | mydomain.com | Use main domain for wildcard certificate or subdomain for subdomain certificate |
 | SETUP_SERVICES | (SSTP WWW API) | Array of services for which certificate will be installed |
 | SSH_STRICT_KEY_CHECKING | yes | Allows to override SSH option StrictHostKeyChecking |
@@ -117,7 +117,7 @@ certbot certonly --preferred-challenges=dns --manual -d $DOMAIN --manual-public-
 ```
 
 ---
-### Licence MIT
+### License MIT
 Copyright 2018 Konstantin Gimpel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ vim /opt/letsencrypt-routeros/letsencrypt-routeros.settings
 | DOMAIN | mydomain.com | Use main domain for wildcard certificate or subdomain for subdomain certificate |
 | SETUP_SERVICES | (SSTP WWW API) | Array of services for which certificate will be installed |
 | SSH_STRICT_KEY_CHECKING | yes | Allows to override SSH option StrictHostKeyChecking |
-| SSH_ACCEPTED_ALGORITHMS | ssh-rsa,ssh-dsa | Allows to override SSH option PubkeyAcceptedAlgorithms |
 
 
 Change permissions:

--- a/letsencrypt-routeros.settings
+++ b/letsencrypt-routeros.settings
@@ -7,3 +7,10 @@ ROUTEROS_HOST=10.0.254.254
 ROUTEROS_SSH_PORT=22
 ROUTEROS_PRIVATE_KEY=/opt/letsencrypt-routeros/id_rsa
 DOMAIN=vpnserver.yourdomain.com
+## Uncomment this to specify array of services that will be setup
+## If not specified certificate is installed to (SSTP WWW API)
+#SETUP_SERVICES=(WWW API)
+## Uncomment this to disable StrictHostKeyChecking (default yes)
+#SSH_STRICT_KEY_CHECKING=no
+## Uncomment this to specify PubkeyAcceptedAlgorithms (default ssh-rsa,ssh-dsa)
+#SSH_ACCEPTED_ALGORITHMS=ssh-dsa

--- a/letsencrypt-routeros.settings
+++ b/letsencrypt-routeros.settings
@@ -12,5 +12,3 @@ DOMAIN=vpnserver.yourdomain.com
 #SETUP_SERVICES=(WWW API)
 ## Uncomment this to disable StrictHostKeyChecking (default yes)
 #SSH_STRICT_KEY_CHECKING=no
-## Uncomment this to specify PubkeyAcceptedAlgorithms (default ssh-rsa,ssh-dsa)
-#SSH_ACCEPTED_ALGORITHMS=ssh-dsa

--- a/letsencrypt-routeros.sh
+++ b/letsencrypt-routeros.sh
@@ -47,10 +47,10 @@ echo "  Using certificate ${CERTIFICATE}"
 echo "  User private key ${KEY}"
 
 #Create alias for RouterOS command
-routeros="ssh -o PubkeyAcceptedAlgorithms=${SSH_ACCEPTED_ALGORITHMS:-ssh-dss,ssh-rsa} -o StrictHostKeyChecking=${SSH_STRICT_KEY_CHECKING:-yes} -i ${ROUTEROS_PRIVATE_KEY} ${ROUTEROS_USER}@${ROUTEROS_HOST} -p ${ROUTEROS_SSH_PORT}"
+routeros="ssh -o PubkeyAcceptedKeyTypes=+ssh-dss -o StrictHostKeyChecking=${SSH_STRICT_KEY_CHECKING:-yes} -i ${ROUTEROS_PRIVATE_KEY} ${ROUTEROS_USER}@${ROUTEROS_HOST} -p ${ROUTEROS_SSH_PORT}"
 
 #Create alias for scp command
-scp="scp -q -o PubkeyAcceptedAlgorithms=${SSH_ACCEPTED_ALGORITHMS:-ssh-dss,ssh-rsa} -o StrictHostKeyChecking=${SSH_STRICT_KEY_CHECKING:-yes} -P ${ROUTEROS_SSH_PORT} -i ${ROUTEROS_PRIVATE_KEY}"
+scp="scp -q -o PubkeyAcceptedKeyTypes=+ssh-dss -o StrictHostKeyChecking=${SSH_STRICT_KEY_CHECKING:-yes} -P ${ROUTEROS_SSH_PORT} -i ${ROUTEROS_PRIVATE_KEY}"
 
 echo ""
 echo "Checking connection to RouterOS"

--- a/letsencrypt-routeros.sh
+++ b/letsencrypt-routeros.sh
@@ -1,56 +1,58 @@
 #!/bin/bash
-#set -x
 
 while getopts 'u:h:p:k:d:c:' OPTION; do
 	case "$OPTION" in
-		u)
-			ROUTEROS_USER=${OPTARG}
-			;;
-		h)
-			ROUTEROS_HOST=${OPTARG}
-			;;
-		p)
-			ROUTEROS_SSH_PORT=${OPTARG}
-			;;
-		k)
-			ROUTEROS_PRIVATE_KEY=${OPTARG}
-			;;
-		d)
-			DOMAIN=${OPTARG}
-			;;
-		c)
-			CONFIG=${OPTARG}
-			;;
-		esac
+	u)
+		ROUTEROS_USER=$OPTARG
+		;;
+	h)
+		ROUTEROS_HOST=$OPTARG
+		;;
+	p)
+		ROUTEROS_SSH_PORT=$OPTARG
+		;;
+	k)
+		ROUTEROS_PRIVATE_KEY=$OPTARG
+		;;
+	d)
+		DOMAIN=$OPTARG
+		;;
+	c)
+		CONFIG=$OPTARG
+		;;
+	*)
+		echo "Unknown option '$OPTION'"
+		;;
+	esac
 done
-shift "$(($OPTIND -1))"
+shift "$((OPTIND - 1))"
 
-if [[ -n ${CONFIG} ]]; then
-	source $CONFIG
-elif [[ -z ${ROUTEROS_USER} ]] || [[ -z ${ROUTEROS_HOST} ]] || [[ -z ${ROUTEROS_SSH_PORT} ]] || [[ -z ${ROUTEROS_PRIVATE_KEY} ]] || [[ -z ${DOMAIN} ]]; then
-        echo -e "Usage:\n$0 -c /path/to/config\nOR\n$0 -u [RouterOS User] -h [RouterOS Host] -p [SSH Port] -k [SSH Private Key] -d [Domain]"
+if [[ -n $CONFIG ]]; then
+	source "$CONFIG"
+elif [[ -z $ROUTEROS_USER ]] || [[ -z $ROUTEROS_HOST ]] || [[ -z $ROUTEROS_SSH_PORT ]] || [[ -z $ROUTEROS_PRIVATE_KEY ]] || [[ -z $DOMAIN ]]; then
+	echo -e "Usage:\n$0 -c /path/to/config\nOR\n$0 -u [RouterOS User] -h [RouterOS Host] -p [SSH Port] -k [SSH Private Key] -d [Domain]"
 	exit 1
 fi
 
-if [[ -z ${ROUTEROS_USER} ]] || [[ -z ${ROUTEROS_HOST} ]] || [[ -z ${ROUTEROS_SSH_PORT} ]] || [[ -z ${ROUTEROS_PRIVATE_KEY} ]] || [[ -z ${DOMAIN} ]]; then
-        echo "Check the config file ${CONFIG_FILE} or start with params: $0 -u [RouterOS User] -h [RouterOS Host] -p [SSH Port] -k [SSH Private Key] -d [Domain]"
-        echo "Please avoid spaces"
-        exit 1
+if [[ -z $ROUTEROS_USER ]] || [[ -z $ROUTEROS_HOST ]] || [[ -z $ROUTEROS_SSH_PORT ]] || [[ -z $ROUTEROS_PRIVATE_KEY ]] || [[ -z $DOMAIN ]]; then
+	echo "Check the config file $CONFIG_FILE or start with params: $0 -u [RouterOS User] -h [RouterOS Host] -p [SSH Port] -k [SSH Private Key] -d [Domain]"
+	echo "Please avoid spaces"
+	exit 1
 fi
 
 CERTIFICATE=/etc/letsencrypt/live/${DOMAIN}/cert.pem
 KEY=/etc/letsencrypt/live/${DOMAIN}/privkey.pem
 
 echo ""
-echo "Updating certificate for ${DOMAIN}"
-echo "  Using certificate ${CERTIFICATE}"
-echo "  User private key ${KEY}"
+echo "Updating certificate for $DOMAIN"
+echo "  Using certificate $CERTIFICATE"
+echo "  User private key $KEY"
 
 #Create alias for RouterOS command
-routeros="ssh -o PubkeyAcceptedKeyTypes=+ssh-dss -o StrictHostKeyChecking=${SSH_STRICT_KEY_CHECKING:-yes} -i ${ROUTEROS_PRIVATE_KEY} ${ROUTEROS_USER}@${ROUTEROS_HOST} -p ${ROUTEROS_SSH_PORT}"
+routeros="ssh -o PubkeyAcceptedKeyTypes=+ssh-dss -o StrictHostKeyChecking=${SSH_STRICT_KEY_CHECKING:-yes} -i $ROUTEROS_PRIVATE_KEY ${ROUTEROS_USER}@${ROUTEROS_HOST} -p $ROUTEROS_SSH_PORT"
 
 #Create alias for scp command
-scp="scp -q -o PubkeyAcceptedKeyTypes=+ssh-dss -o StrictHostKeyChecking=${SSH_STRICT_KEY_CHECKING:-yes} -P ${ROUTEROS_SSH_PORT} -i ${ROUTEROS_PRIVATE_KEY}"
+scp="scp -q -o PubkeyAcceptedKeyTypes=+ssh-dss -o StrictHostKeyChecking=${SSH_STRICT_KEY_CHECKING:-yes} -P $ROUTEROS_SSH_PORT -i $ROUTEROS_PRIVATE_KEY"
 
 echo ""
 echo "Checking connection to RouterOS"
@@ -60,23 +62,23 @@ $routeros /system resource print
 RESULT=$?
 
 if [[ ! ${RESULT} == 0 ]]; then
-        echo -e "\nError in: $routeros"
-        echo "More info: https://wiki.mikrotik.com/wiki/Use_SSH_to_execute_commands_(DSA_key_login)"
-        exit 1
+	echo -e "\nError in: $routeros"
+	echo "More info: https://wiki.mikrotik.com/wiki/Use_SSH_to_execute_commands_(DSA_key_login)"
+	exit 1
 else
-        echo -e "\nConnection to RouterOS Successful!\n" 
+	echo -e "\nConnection to RouterOS Successful!\n"
 fi
 
-if [ ! -f ${CERTIFICATE} ] && [ ! -f ${KEY} ]; then
-        echo -e "\nFile(s) not found:\n${CERTIFICATE}\n${KEY}\n"
-        echo -e "Please use CertBot Let'sEncrypt:"
-        echo "============================"
-        echo "certbot certonly --preferred-challenges=dns --manual -d ${DOMAIN} --manual-public-ip-logging-ok"
-        echo "or (for wildcard certificate):"
-        echo "certbot certonly --preferred-challenges=dns --manual -d *.${DOMAIN} --manual-public-ip-logging-ok --server https://acme-v02.api.letsencrypt.org/directory"
-        echo "==========================="
-        echo -e "and follow instructions from CertBot\n"
-        exit 1
+if [ ! -f "$CERTIFICATE" ] && [ ! -f "$KEY" ]; then
+	echo -e "\nFile(s) not found:\n${CERTIFICATE}\n${KEY}\n"
+	echo -e "Please use CertBot Let'sEncrypt:"
+	echo "============================"
+	echo "certbot certonly --preferred-challenges=dns --manual -d $DOMAIN --manual-public-ip-logging-ok"
+	echo "or (for wildcard certificate):"
+	echo "certbot certonly --preferred-challenges=dns --manual -d *.$DOMAIN --manual-public-ip-logging-ok --server https://acme-v02.api.letsencrypt.org/directory"
+	echo "==========================="
+	echo -e "and follow instructions from CertBot\n"
+	exit 1
 fi
 
 # Set up variables to remove errors
@@ -85,61 +87,61 @@ DOMAIN_CERT_FILE=${DOMAIN}.pem
 DOMAIN_KEY_FILE=${DOMAIN}.key
 
 # Remove previous certificate
-echo "Removing old certificate from installed certificates: ${DOMAIN_INSTALLED_CERT_FILE}"
-$routeros /certificate remove [find name=${DOMAIN_INSTALLED_CERT_FILE}]
+echo "Removing old certificate from installed certificates: $DOMAIN_INSTALLED_CERT_FILE"
+$routeros /certificate remove [find name="$DOMAIN_INSTALLED_CERT_FILE"]
 
 echo ""
 echo "Handling new certificate file"
 # Create Certificate
 # Delete Certificate file if the file exist on RouterOS
-echo "  Deleting any old copy of certificate file from disk: ${DOMAIN_CERT_FILE}"
-$routeros /file remove ${DOMAIN_CERT_FILE} > /dev/null
+echo "  Deleting any old copy of certificate file from disk: $DOMAIN_CERT_FILE"
+$routeros /file remove "$DOMAIN_CERT_FILE" >/dev/null
 # Upload Certificate to RouterOS
-echo "  Uploading new domain certificate file to router: ${CERTIFICATE}"
-$scp "${CERTIFICATE}" "${ROUTEROS_USER}"@"${ROUTEROS_HOST}":"${DOMAIN_CERT_FILE}"
+echo "  Uploading new domain certificate file to router: $CERTIFICATE"
+$scp "$CERTIFICATE" "$ROUTEROS_USER"@"$ROUTEROS_HOST":"$DOMAIN_CERT_FILE"
 sleep 2
 # Import Certificate file
 echo "  Importing new certificate file to router certificates"
-$routeros /certificate import file-name=${DOMAIN_CERT_FILE} passphrase=\"\"
+$routeros /certificate import file-name="$DOMAIN_CERT_FILE" passphrase=\"\"
 # Delete Certificate file after import
-echo "  Deleting any new copy of certificate file from disk: ${DOMAIN_CERT_FILE}"
-$routeros /file remove ${DOMAIN_CERT_FILE}
+echo "  Deleting any new copy of certificate file from disk: $DOMAIN_CERT_FILE"
+$routeros /file remove "$DOMAIN_CERT_FILE"
 
 echo ""
 echo "Handling new key file"
 # Create Key
 # Delete Certificate file if the file exist on RouterOS
 echo "  Deleting any old copy of key file from disk: ${DOMAIN_KEY_FILE}"
-$routeros /file remove ${DOMAIN_KEY_FILE} > /dev/null
+$routeros /file remove "$DOMAIN_KEY_FILE" >/dev/null
 # Upload Key to RouterOS
-echo "  Uploading new domain key file to router: ${KEY}"
-$scp "${KEY}" "${ROUTEROS_USER}"@"${ROUTEROS_HOST}":"${DOMAIN_KEY_FILE}"
+echo "  Uploading new domain key file to router: $KEY"
+$scp "$KEY" "$ROUTEROS_USER"@"$ROUTEROS_HOST":"$DOMAIN_KEY_FILE"
 sleep 2
 # Import Key file
 echo "  Importing new key file to router certificates"
-$routeros /certificate import file-name=${DOMAIN_KEY_FILE} passphrase=\"\"
+$routeros /certificate import file-name="$DOMAIN_KEY_FILE" passphrase=\"\"
 # Delete Certificate file after import
-echo "  Deleting any new copy of key file from disk: ${DOMAIN_KEY_FILE}"
-$routeros /file remove ${DOMAIN_KEY_FILE}
+echo "  Deleting any new copy of key file from disk: $DOMAIN_KEY_FILE"
+$routeros /file remove "$DOMAIN_KEY_FILE"
 
 echo ""
 
 # Setup Certificate to SSTP Service
 if [[ "${SETUP_SERVICES[*]:-SSTP}" =~ "SSTP" ]]; then
-	echo "Updating SSTP Server to use ${DOMAIN_INSTALLED_CERT_FILE}"
-	$routeros /interface sstp-server server set certificate=${DOMAIN_INSTALLED_CERT_FILE}
+	echo "Updating SSTP Server to use $DOMAIN_INSTALLED_CERT_FILE"
+	$routeros /interface sstp-server server set certificate="$DOMAIN_INSTALLED_CERT_FILE"
 fi
 
 # Setup Certificate to WWW Service
 if [[ "${SETUP_SERVICES[*]:-WWW}" =~ "WWW" ]]; then
-	echo "Updating HTTPS Server to use ${DOMAIN_INSTALLED_CERT_FILE}"
-	$routeros /ip service set www-ssl certificate=${DOMAIN_INSTALLED_CERT_FILE}
+	echo "Updating HTTPS Server to use $DOMAIN_INSTALLED_CERT_FILE"
+	$routeros /ip service set www-ssl certificate="$DOMAIN_INSTALLED_CERT_FILE"
 fi
 
 # Setup Certificat to API Service
 if [[ "${SETUP_SERVICES[*]:-API}" =~ "API" ]]; then
-	echo "Updating API SSL Server to use ${DOMAIN_INSTALLED_CERT_FILE}"
-	$routeros /ip service set api-ssl certificate=${DOMAIN_INSTALLED_CERT_FILE}
+	echo "Updating API SSL Server to use $DOMAIN_INSTALLED_CERT_FILE"
+	$routeros /ip service set api-ssl certificate="$DOMAIN_INSTALLED_CERT_FILE"
 fi
 
 exit 0

--- a/letsencrypt-routeros.sh
+++ b/letsencrypt-routeros.sh
@@ -1,33 +1,56 @@
 #!/bin/bash
-CONFIG_FILE=letsencrypt-routeros.settings
+#set -x
 
-if [[ -z $1 ]] || [[ -z $2 ]] || [[ -z $3 ]] || [[ -z $4 ]] || [[ -z $5 ]]; then
-        echo -e "Usage: $0 or $0 [RouterOS User] [RouterOS Host] [SSH Port] [SSH Private Key] [Domain]\n"
-        source $CONFIG_FILE
-else
-        ROUTEROS_USER=$1
-        ROUTEROS_HOST=$2
-        ROUTEROS_SSH_PORT=$3
-        ROUTEROS_PRIVATE_KEY=$4
-        DOMAIN=$5
+while getopts 'u:h:p:k:d:c:' OPTION; do
+	case "$OPTION" in
+		u)
+			ROUTEROS_USER=${OPTARG}
+			;;
+		h)
+			ROUTEROS_HOST=${OPTARG}
+			;;
+		p)
+			ROUTEROS_SSH_PORT=${OPTARG}
+			;;
+		k)
+			ROUTEROS_PRIVATE_KEY=${OPTARG}
+			;;
+		d)
+			DOMAIN=${OPTARG}
+			;;
+		c)
+			CONFIG=${OPTARG}
+			;;
+		esac
+done
+shift "$(($OPTIND -1))"
+
+if [[ -n ${CONFIG} ]]; then
+	source $CONFIG
+elif [[ -z ${ROUTEROS_USER} ]] || [[ -z ${ROUTEROS_HOST} ]] || [[ -z ${ROUTEROS_SSH_PORT} ]] || [[ -z ${ROUTEROS_PRIVATE_KEY} ]] || [[ -z ${DOMAIN} ]]; then
+        echo -e "Usage:\n$0 -c /path/to/config\nOR\n$0 -u [RouterOS User] -h [RouterOS Host] -p [SSH Port] -k [SSH Private Key] -d [Domain]"
+	exit 1
 fi
 
-if [[ -z $ROUTEROS_USER ]] || [[ -z $ROUTEROS_HOST ]] || [[ -z $ROUTEROS_SSH_PORT ]] || [[ -z $ROUTEROS_PRIVATE_KEY ]] || [[ -z $DOMAIN ]]; then
-        echo "Check the config file $CONFIG_FILE or start with params: $0 [RouterOS User] [RouterOS Host] [SSH Port] [SSH Private Key] [Domain]"
+if [[ -z ${ROUTEROS_USER} ]] || [[ -z ${ROUTEROS_HOST} ]] || [[ -z ${ROUTEROS_SSH_PORT} ]] || [[ -z ${ROUTEROS_PRIVATE_KEY} ]] || [[ -z ${DOMAIN} ]]; then
+        echo "Check the config file ${CONFIG_FILE} or start with params: $0 -u [RouterOS User] -h [RouterOS Host] -p [SSH Port] -k [SSH Private Key] -d [Domain]"
         echo "Please avoid spaces"
         exit 1
 fi
 
-CERTIFICATE=/etc/letsencrypt/live/$DOMAIN/cert.pem
-KEY=/etc/letsencrypt/live/$DOMAIN/privkey.pem
+CERTIFICATE=/etc/letsencrypt/live/${DOMAIN}/cert.pem
+KEY=/etc/letsencrypt/live/${DOMAIN}/privkey.pem
 
 echo ""
-echo "Updating certificate for $DOMAIN"
-echo "  Using certificate $CERTIFICATE"
-echo "  User private key $KEY"
+echo "Updating certificate for ${DOMAIN}"
+echo "  Using certificate ${CERTIFICATE}"
+echo "  User private key ${KEY}"
 
 #Create alias for RouterOS command
-routeros="ssh -i $ROUTEROS_PRIVATE_KEY $ROUTEROS_USER@$ROUTEROS_HOST -p $ROUTEROS_SSH_PORT"
+routeros="ssh -o PubkeyAcceptedAlgorithms=${SSH_ACCEPTED_ALGORITHMS:-ssh-dss,ssh-rsa} -o StrictHostKeyChecking=${SSH_STRICT_KEY_CHECKING:-yes} -i ${ROUTEROS_PRIVATE_KEY} ${ROUTEROS_USER}@${ROUTEROS_HOST} -p ${ROUTEROS_SSH_PORT}"
+
+#Create alias for scp command
+scp="scp -q -o PubkeyAcceptedAlgorithms=${SSH_ACCEPTED_ALGORITHMS:-ssh-dss,ssh-rsa} -o StrictHostKeyChecking=${SSH_STRICT_KEY_CHECKING:-yes} -P ${ROUTEROS_SSH_PORT} -i ${ROUTEROS_PRIVATE_KEY}"
 
 echo ""
 echo "Checking connection to RouterOS"
@@ -36,7 +59,7 @@ echo "Checking connection to RouterOS"
 $routeros /system resource print
 RESULT=$?
 
-if [[ ! $RESULT == 0 ]]; then
+if [[ ! ${RESULT} == 0 ]]; then
         echo -e "\nError in: $routeros"
         echo "More info: https://wiki.mikrotik.com/wiki/Use_SSH_to_execute_commands_(DSA_key_login)"
         exit 1
@@ -44,72 +67,79 @@ else
         echo -e "\nConnection to RouterOS Successful!\n" 
 fi
 
-if [ ! -f $CERTIFICATE ] && [ ! -f $KEY ]; then
-        echo -e "\nFile(s) not found:\n$CERTIFICATE\n$KEY\n"
+if [ ! -f ${CERTIFICATE} ] && [ ! -f ${KEY} ]; then
+        echo -e "\nFile(s) not found:\n${CERTIFICATE}\n${KEY}\n"
         echo -e "Please use CertBot Let'sEncrypt:"
         echo "============================"
-        echo "certbot certonly --preferred-challenges=dns --manual -d $DOMAIN --manual-public-ip-logging-ok"
+        echo "certbot certonly --preferred-challenges=dns --manual -d ${DOMAIN} --manual-public-ip-logging-ok"
         echo "or (for wildcard certificate):"
-        echo "certbot certonly --preferred-challenges=dns --manual -d *.$DOMAIN --manual-public-ip-logging-ok --server https://acme-v02.api.letsencrypt.org/directory"
+        echo "certbot certonly --preferred-challenges=dns --manual -d *.${DOMAIN} --manual-public-ip-logging-ok --server https://acme-v02.api.letsencrypt.org/directory"
         echo "==========================="
         echo -e "and follow instructions from CertBot\n"
         exit 1
 fi
 
 # Set up variables to remove errors
-DOMAIN_INSTALLED_CERT_FILE=$DOMAIN.pem_0
-DOMAIN_CERT_FILE=$DOMAIN.pem
-DOMAIN_KEY_FILE=$DOMAIN.key
+DOMAIN_INSTALLED_CERT_FILE=${DOMAIN}.pem_0
+DOMAIN_CERT_FILE=${DOMAIN}.pem
+DOMAIN_KEY_FILE=${DOMAIN}.key
 
 # Remove previous certificate
-echo "Removing old certificate from installed certificates: $DOMAIN_INSTALLED_CERT_FILE"
-$routeros /certificate remove [find name=$DOMAIN_INSTALLED_CERT_FILE]
+echo "Removing old certificate from installed certificates: ${DOMAIN_INSTALLED_CERT_FILE}"
+$routeros /certificate remove [find name=${DOMAIN_INSTALLED_CERT_FILE}]
 
 echo ""
 echo "Handling new certificate file"
 # Create Certificate
 # Delete Certificate file if the file exist on RouterOS
-echo "  Deleting any old copy of certificate file from disk: $DOMAIN_CERT_FILE"
-$routeros /file remove $DOMAIN_CERT_FILE > /dev/null
+echo "  Deleting any old copy of certificate file from disk: ${DOMAIN_CERT_FILE}"
+$routeros /file remove ${DOMAIN_CERT_FILE} > /dev/null
 # Upload Certificate to RouterOS
-echo "  Uploading new domain certificate file to router: $CERTIFICATE"
-scp -q -P $ROUTEROS_SSH_PORT -i "$ROUTEROS_PRIVATE_KEY" "$CERTIFICATE" "$ROUTEROS_USER"@"$ROUTEROS_HOST":"$DOMAIN_CERT_FILE"
+echo "  Uploading new domain certificate file to router: ${CERTIFICATE}"
+$scp "${CERTIFICATE}" "${ROUTEROS_USER}"@"${ROUTEROS_HOST}":"${DOMAIN_CERT_FILE}"
 sleep 2
 # Import Certificate file
 echo "  Importing new certificate file to router certificates"
-$routeros /certificate import file-name=$DOMAIN_CERT_FILE passphrase=\"\"
+$routeros /certificate import file-name=${DOMAIN_CERT_FILE} passphrase=\"\"
 # Delete Certificate file after import
-echo "  Deleting any new copy of certificate file from disk: $DOMAIN_CERT_FILE"
-$routeros /file remove $DOMAIN_CERT_FILE
+echo "  Deleting any new copy of certificate file from disk: ${DOMAIN_CERT_FILE}"
+$routeros /file remove ${DOMAIN_CERT_FILE}
 
 echo ""
 echo "Handling new key file"
 # Create Key
 # Delete Certificate file if the file exist on RouterOS
-echo "  Deleting any old copy of key file from disk: $DOMAIN_KEY_FILE"
-$routeros /file remove $DOMAIN_KEY_FILE > /dev/null
+echo "  Deleting any old copy of key file from disk: ${DOMAIN_KEY_FILE}"
+$routeros /file remove ${DOMAIN_KEY_FILE} > /dev/null
 # Upload Key to RouterOS
-echo "  Uploading new domain key file to router: $KEY"
-scp -q -P $ROUTEROS_SSH_PORT -i "$ROUTEROS_PRIVATE_KEY" "$KEY" "$ROUTEROS_USER"@"$ROUTEROS_HOST":"$DOMAIN_KEY_FILE"
+echo "  Uploading new domain key file to router: ${KEY}"
+$scp "${KEY}" "${ROUTEROS_USER}"@"${ROUTEROS_HOST}":"${DOMAIN_KEY_FILE}"
 sleep 2
 # Import Key file
 echo "  Importing new key file to router certificates"
-$routeros /certificate import file-name=$DOMAIN_KEY_FILE passphrase=\"\"
+$routeros /certificate import file-name=${DOMAIN_KEY_FILE} passphrase=\"\"
 # Delete Certificate file after import
-echo "  Deleting any new copy of key file from disk: $DOMAIN_KEY_FILE"
-$routeros /file remove $DOMAIN_KEY_FILE
+echo "  Deleting any new copy of key file from disk: ${DOMAIN_KEY_FILE}"
+$routeros /file remove ${DOMAIN_KEY_FILE}
 
 echo ""
 
-# Setup Certificate to SSTP Server
-echo "Updating SSTP Server to use $DOMAIN_INSTALLED_CERT_FILE"
-$routeros /interface sstp-server server set certificate=$DOMAIN_INSTALLED_CERT_FILE
+# Setup Certificate to SSTP Service
+if [[ "${SETUP_SERVICES[*]:-SSTP}" =~ "SSTP" ]]; then
+	echo "Updating SSTP Server to use ${DOMAIN_INSTALLED_CERT_FILE}"
+	$routeros /interface sstp-server server set certificate=${DOMAIN_INSTALLED_CERT_FILE}
+fi
 
-# Setup Certificate to SSL
-echo "Updating HTTPS Server to use $DOMAIN_INSTALLED_CERT_FILE"
-$routeros /ip service set www-ssl certificate=$DOMAIN_INSTALLED_CERT_FILE
+# Setup Certificate to WWW Service
+if [[ "${SETUP_SERVICES[*]:-WWW}" =~ "WWW" ]]; then
+	echo "Updating HTTPS Server to use ${DOMAIN_INSTALLED_CERT_FILE}"
+	$routeros /ip service set www-ssl certificate=${DOMAIN_INSTALLED_CERT_FILE}
+fi
 
-echo "Updating API SSL Server to use $DOMAIN_INSTALLED_CERT_FILE"
-$routeros /ip service set api-ssl certificate=$DOMAIN_INSTALLED_CERT_FILE
+# Setup Certificat to API Service
+if [[ "${SETUP_SERVICES[*]:-API}" =~ "API" ]]; then
+	echo "Updating API SSL Server to use ${DOMAIN_INSTALLED_CERT_FILE}"
+	$routeros /ip service set api-ssl certificate=${DOMAIN_INSTALLED_CERT_FILE}
+fi
 
 exit 0

--- a/letsencrypt-routeros.sh
+++ b/letsencrypt-routeros.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-while getopts 'u:h:p:k:d:c:' OPTION; do
+while getopts 'u:h:p:k:d:f:' OPTION; do
 	case "$OPTION" in
 	u)
 		ROUTEROS_USER=$OPTARG
@@ -17,7 +17,7 @@ while getopts 'u:h:p:k:d:c:' OPTION; do
 	d)
 		DOMAIN=$OPTARG
 		;;
-	c)
+	f)
 		CONFIG=$OPTARG
 		;;
 	*)
@@ -138,7 +138,7 @@ if [[ "${SETUP_SERVICES[*]:-WWW}" =~ "WWW" ]]; then
 	$routeros /ip service set www-ssl certificate="$DOMAIN_INSTALLED_CERT_FILE"
 fi
 
-# Setup Certificat to API Service
+# Setup Certificate to API Service
 if [[ "${SETUP_SERVICES[*]:-API}" =~ "API" ]]; then
 	echo "Updating API SSL Server to use $DOMAIN_INSTALLED_CERT_FILE"
 	$routeros /ip service set api-ssl certificate="$DOMAIN_INSTALLED_CERT_FILE"


### PR DESCRIPTION
`Starting with the 7.0 release of OpenSSH, support for ssh-dss keys has been disabled by default at runtime due to their inherit weakness.`
Fixed by passing additional SSH option. Also added argument parsing and few other options that might be useful on some systems like on mine.